### PR TITLE
Feature/qca/000005/fix qc issues

### DIFF
--- a/xobox/utils/convert.py
+++ b/xobox/utils/convert.py
@@ -39,7 +39,7 @@ def to_str(value):
     :param value: The value to be converted
     :return: Resulting string
     """
-    if isinstance(value, bytes) or isinstance(value, bytearray):
+    if isinstance(value, (bytes, bytearray)):
         return value.decode(encoding=get_conf('DEFAULT_CHARSET'), errors='replace')
     elif value is None:
         return ''

--- a/xobox/utils/dynamic.py
+++ b/xobox/utils/dynamic.py
@@ -96,10 +96,12 @@ class DynamicIterable(UserDict, object):
         """
         Dynamically add property to the current class object
         """
-        setattr(self.__class__, name, property(
-            fget=lambda self: self.__getattr__(name),
-            fset=lambda self, value: self.__setitem__(name, value),
-            doc=doc)
+        setattr(
+            self.__class__, name, property(
+                fget=lambda self: self.__getattr__(name),
+                fset=lambda self, value: self.__setitem__(name, value),
+                doc=doc
+            )
         )
 
     def __del_property(self, name):

--- a/xobox/utils/dynamic.py
+++ b/xobox/utils/dynamic.py
@@ -27,8 +27,7 @@ class Dynamic(object):
         """
         Dynamically add property (read-only) to the current class object
         """
-        fget = lambda self: self._get_property(name)
-        setattr(self.__class__, name, property(fget, doc=doc))
+        setattr(self.__class__, name, property(fget=lambda self: self._get_property(name), doc=doc))
         setattr(self, '_' + name, value)
 
     def _get_property(self, name):
@@ -97,9 +96,11 @@ class DynamicIterable(UserDict, object):
         """
         Dynamically add property to the current class object
         """
-        fget = lambda self: self.__getattr__(name)
-        fset = lambda self, value: self.__setitem__(name, value)
-        setattr(self.__class__, name, property(fget=fget, fset=fset, doc=doc))
+        setattr(self.__class__, name, property(
+            fget=lambda self: self.__getattr__(name),
+            fset=lambda self, value: self.__setitem__(name, value),
+            doc=doc)
+        )
 
     def __del_property(self, name):
         """


### PR DESCRIPTION
### Summary

Fix the four detected QuantifiedCode issues:

* 1 [isinstance() tuple use](https://www.quantifiedcode.com/app/issue_class/4BNYFK47)
* 3 [lambda assignments](https://www.quantifiedcode.com/app/issue_class/6803rnFX)

### Benefits

* code is easier to read
* avoid unnamed function references

### Drawbacks and Risks 

* signature for `setattr` within `DynamicIterable.__add_property` method has become more complex

### Alternate Designs

Technically, it would have been possible to implement `fget` and `fset` as inner functions:

```
def __add_property(self, name, value, doc=None):
    def fget(self, name):
        return self.__getattr__(name)
```

However, this would have created additional lines of code, and a hassle with the name spaces as we'd be dealing with private (i. e. `__abc`) members within an inner function of a non-static method. This was considered so ugly and hard to understand that the current solution was largely preferred.

### Applicable Issues

Fixes #5 
