### PR TITLE
Feature/qca/000031/fix identical 101

### DIFF
--- a/scripts/runtest.py
+++ b/scripts/runtest.py
@@ -44,38 +44,6 @@ def __get_version(version=None):
     return main_part + sub
 
 
-def __filter_files(item):
-    """
-    Filter for Python modules beginning with *test_*
-    
-    :param str item: the item to be tested with this filter
-    """
-    file, ext = os.path.splitext(item)
-    if file != '__init__' and ext == '.py' and file[:5] == 'test_':
-        return True
-    return False
-
-
-def __filter_members(item):
-    """
-    Filter function to detect classes within a module or package
-    
-    :param str item: the item to be tested with this filter
-    """
-    exclude = (
-        re.escape('__builtins__'),
-        re.escape('__cached__'),
-        re.escape('__doc__'),
-        re.escape('__file__'),
-        re.escape('__loader__'),
-        re.escape('__name__'),
-        re.escape('__package__'),
-        re.escape('__path__')
-    )
-    pattern = re.compile('|'.join(exclude))
-    return not pattern.search(item)
-
-
 def __write_untested(label, result):
     """
     Print information on non-executed tests
@@ -107,6 +75,8 @@ def main():
     if os.path.isfile(os.path.join(xobox_path, 'xobox', '__init__.py')):
         sys.path.insert(0, xobox_path)
 
+    from xobox.utils import filters
+
     test_classes = []
     test_dir = os.path.join(xobox_path, 'tests')
 
@@ -114,13 +84,13 @@ def main():
     # modules derived from :py:class:`~unittest.TestCase`
     for root, dirs, files in os.walk(test_dir):
         module_prefix = '.'.join(str(os.path.relpath(root, os.path.dirname(test_dir))).split(os.path.sep))
-        for mod in filter(__filter_files, files):
+        for mod in filter(filters.files, files):
             try:
                 candidate = importlib.import_module('.'.join((module_prefix, os.path.splitext(mod)[0])))
             except ImportError:
                 candidate = None
             if candidate:
-                for member in filter(__filter_members, dir(candidate)):
+                for member in filter(filters.members, dir(candidate)):
                     try:
                         if issubclass(getattr(candidate, member), unittest.TestCase) \
                            and getattr(candidate, member).__name__ != unittest.TestCase.__name__:

--- a/xobox/utils/filters.py
+++ b/xobox/utils/filters.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+"""
+    xobox.utils.filter
+    ~~~~~~~~~~~~~~~~~~
+
+    :copyright: Copyright 2017 by The Stormrose Project team, see AUTHORS.
+    :license: MIT License, see LICENSE for details.
+"""
+
+
+import os
+import re
+
+
+def files(item):
+    """
+    Filter for Python modules beginning with *test_*
+    
+    :param str item: the item to be tested with this filter
+    """
+    file, ext = os.path.splitext(item)
+    if file != '__init__' and ext == '.py' and file[:5] == 'test_':
+        return True
+    return False
+
+
+def members(item):
+    """
+    Filter function to detect classes within a module or package
+
+    :param str item: the item to be tested with this filter
+    """
+    exclude = (
+        re.escape('__builtins__'),
+        re.escape('__cached__'),
+        re.escape('__doc__'),
+        re.escape('__file__'),
+        re.escape('__loader__'),
+        re.escape('__name__'),
+        re.escape('__package__'),
+        re.escape('__path__')
+    )
+    pattern = re.compile('|'.join(exclude))
+    return not pattern.search(item)
+
+
+def modules(item):
+    """
+    Filter function to detect processor modules and packages
+
+    :param str item: the item to be tested with this filter
+    """
+    exclude = (
+        re.escape('__init__.py'),
+    )
+    pattern = re.compile('|'.join(exclude))
+    return not pattern.search(item)

--- a/xobox/utils/loader.py
+++ b/xobox/utils/loader.py
@@ -10,40 +10,7 @@
 
 import importlib
 import os
-import re
-
-
-def __filter_members(item):
-    """
-    Filter function to detect classes within a module or package
-    
-    :param str item: the item to be tested with this filter
-    """
-    exclude = (
-        re.escape('__builtins__'),
-        re.escape('__cached__'),
-        re.escape('__doc__'),
-        re.escape('__file__'),
-        re.escape('__loader__'),
-        re.escape('__name__'),
-        re.escape('__package__'),
-        re.escape('__path__')
-    )
-    pattern = re.compile('|'.join(exclude))
-    return not pattern.search(item)
-
-
-def __filter_modules(item):
-    """
-    Filter function to detect processor modules and packages
-    
-    :param str item: the item to be tested with this filter
-    """
-    exclude = (
-        re.escape('__init__.py'),
-    )
-    pattern = re.compile('|'.join(exclude))
-    return not pattern.search(item)
+from xobox.utils import filters
 
 
 def detect_class_modules(mod, parent=object):
@@ -73,7 +40,7 @@ def detect_class_modules(mod, parent=object):
         gen_dir = os.listdir(os.path.dirname(os.path.realpath(package_instance.__file__)))
 
         # only consider modules and packages, and exclude the base module
-        for file_candidate in filter(__filter_modules, gen_dir):
+        for file_candidate in filter(filters.modules, gen_dir):
 
             # Python files are modules; the name needs to be without file ending
             if file_candidate[-3:] == '.py':
@@ -94,7 +61,7 @@ def detect_class_modules(mod, parent=object):
     # test if any of the candidates contain
     # classes derived from the parent class
     for candidate in candidates:
-        for member_candidate in filter(__filter_members, dir(candidate)):
+        for member_candidate in filter(filters.members, dir(candidate)):
             try:
                 if issubclass(getattr(candidate, member_candidate), parent) \
                    and getattr(candidate, member_candidate).__name__ != parent.__name__:


### PR DESCRIPTION
### Summary

Centralize filter functions in dedicated utility module to avoid code duplication

### Benefits

Avoid / reduce code duplication

### Drawbacks and Risks 

Import in `runtest.py` only possible after setting the python path

### Alternate Designs

* Avoiding imports from `xobox` leads to code duplication
* Additional top-level Python package creates more dependencies

### Applicable Issues

Fixes #31 
