### PR TITLE
Feature/pro/000061/set up test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,10 @@ install:
   - pip install -r requirements.txt
 
 script:
-  - coverage run --source=xobox,scripts scripts/runtest.py
+  - coverage run --source=xobox scripts/runtest.py
   - if [[ "${TRAVIS_PYTHON_VERSION}" == "3.6" ]]; then travis-sphinx --branches=master build; fi
 
 after_success:
-  - CODECLIMATE_REPO_TOKEN=5e6c134005b05a58897baf876391c108b2fab570103fe28030792a48baa001d4 codeclimate-test-reporter
+  - coverage report
+  - if [[ "${TRAVIS_PYTHON_VERSION}" == "3.6" ]]; then CODECLIMATE_REPO_TOKEN=5e6c134005b05a58897baf876391c108b2fab570103fe28030792a48baa001d4 codeclimate-test-reporter
   - if [[ "${TRAVIS_PYTHON_VERSION}" == "3.6" ]]; then travis-sphinx --branches=master deploy; fi


### PR DESCRIPTION
### Summary

Improved coverage detection in Travis CI

### Benefits

* focus on `xobox` package
* only consider one python version (3.6) to avoid random coverage result variation

### Drawbacks and Risks 

None (no code change involved)

### Alternate Designs

Keep coverage result for all three Python versions tested by travis. Problem: Last test wins, and we have no control over the sequence (tests are run in parallel, so it's pure coincidence which test finishes first).

### Applicable Issues

Fixes #62 