### PR TITLE
Feature/qca/000036/fix runtest complexity

### DIFF
--- a/scripts/runtest.py
+++ b/scripts/runtest.py
@@ -25,20 +25,30 @@ except ImportError:
     EX_SOFTWARE = 1
 
 
-def __get_version():
-    """Derive a PEP440-compliant version number from sys.version_info."""
-    version = sys.version_info
+def __get_version_main_part(version):
+    """Derive PEP440-compliant main part from a valid version quintuple"""
     parts = 2 if version[2] == 0 else 3
-    main_part = '.'.join(str(x) for x in version[:parts])
+    return '.'.join(str(x) for x in version[:parts])
 
+
+def __get_version_sub_part(version):
+    """Derive PEP440-compliant sub part from a valid version quintuple"""
     sub = ''
     if version[3] == 'alpha' and version[4] == 0:
         sub = '.dev'
     elif version[3] != 'final':
         mapping = {'alpha': 'a', 'beta': 'b', 'rc': 'rc'}
         sub = mapping[version[3]] + str(version[4])
+    return sub
 
-    return main_part + sub
+
+def __get_version():
+    """Derive a PEP440-compliant version number from sys.version_info."""
+    version = sys.version_info
+    main_part = __get_version_main_part(version)
+    sub_part = __get_version_sub_part(version)
+
+    return main_part + sub_part
 
 
 def __get_untested(test_class, test_set):

--- a/scripts/runtest.py
+++ b/scripts/runtest.py
@@ -175,6 +175,9 @@ def __write_stats(results, skipped, failed):
     total_failed = 0
     total_skipped = 0
 
+    template = "{test: <32}      {passed: >3d}      {failed: >3d}      {skipped: >4d}     {total: >3d}"
+    template += "     {ratio: >3.2%}"
+
     print("\nxobox Unit Test Result Summary:\n\nPython version: {}\n".format(__get_version()))
     print("Test                               Passed   Failed   Skipped   Total    % passed")
     print("================================================================================")
@@ -185,7 +188,7 @@ def __write_stats(results, skipped, failed):
         total_passed = total_tests - total_failed - total_skipped
         ratio = __calc_ratio(results[key][2] - results[key][0] - results[key][1], results[key][2] - results[key][1])
         print(
-            "{test: <32}      {passed: >3d}      {failed: >3d}      {skipped: >4d}     {total: >3d}     {ratio: >3.2%}".format(
+            template.format(
                 test=key,
                 passed=results[key][2] - results[key][0] - results[key][1],
                 failed=results[key][0],
@@ -196,7 +199,7 @@ def __write_stats(results, skipped, failed):
     print("================================================================================")
     ratio = __calc_ratio(total_passed, total_tests - total_skipped)
     print(
-        "{test: <32}      {passed: >3d}      {failed: >3d}      {skipped: >4d}     {total: >3d}     {ratio: >3.2%}\n".format(
+        (template+"\n").format(
             test="TOTAL",
             passed=total_passed,
             failed=total_failed,

--- a/scripts/runtest.py
+++ b/scripts/runtest.py
@@ -221,18 +221,12 @@ def main():
 
     from xobox.utils import filters
 
-    test_classes = []
     test_dir = os.path.join(xobox_path, 'tests')
 
     # look recursively for Python modules in ``test_dir`` and find all classes within those
     # modules derived from :py:class:`~unittest.TestCase`
-    for candidate, member in __get_candidates(test_dir, filters.files, filters.members):
-        try:
-            if issubclass(getattr(candidate, member), unittest.TestCase) \
-               and getattr(candidate, member).__name__ != unittest.TestCase.__name__:
-                test_classes.append(getattr(candidate, member))
-        except TypeError:
-            pass
+    # noinspection PyTypeChecker
+    test_classes = list(__get_tests(test_dir, unittest.TestCase, filters.files, filters.members))
 
     return_code = EX_OK
 

--- a/scripts/runtest.py
+++ b/scripts/runtest.py
@@ -25,11 +25,9 @@ except ImportError:
     EX_SOFTWARE = 1
 
 
-def __get_version(version=None):
-    """Derive a PEP440-compliant version number from VERSION."""
-    version = version or sys.version_info
-    assert len(version) == 5
-    assert version[3] in ('alpha', 'beta', 'rc', 'final')
+def __get_version():
+    """Derive a PEP440-compliant version number from sys.version_info."""
+    version = sys.version_info
     parts = 2 if version[2] == 0 else 3
     main_part = '.'.join(str(x) for x in version[:parts])
 

--- a/scripts/runtest.py
+++ b/scripts/runtest.py
@@ -84,6 +84,20 @@ def __get_untested(test_class, test_set):
     return result
 
 
+def __get_modules(path, filter_function):
+    """
+    Generate a list of modules from a given path
+    
+    :param str path:         location on the file system to scan
+    :param filter_function:  reference to the filter function to be used
+    :return:                 iterable for modules
+    """
+    for root, dirs, files in os.walk(path):
+        module_prefix = '.'.join(str(os.path.relpath(root, os.path.dirname(path))).split(os.path.sep))
+        for mod in filter(filter_function, files):
+            yield '.'.join((module_prefix, os.path.splitext(mod)[0]))
+
+
 def main():
     """
     xobox test script main function

--- a/scripts/runtest.py
+++ b/scripts/runtest.py
@@ -115,21 +115,19 @@ def main():
 
     # look recursively for Python modules in ``test_dir`` and find all classes within those
     # modules derived from :py:class:`~unittest.TestCase`
-    for root, dirs, files in os.walk(test_dir):
-        module_prefix = '.'.join(str(os.path.relpath(root, os.path.dirname(test_dir))).split(os.path.sep))
-        for mod in filter(filters.files, files):
-            try:
-                candidate = importlib.import_module('.'.join((module_prefix, os.path.splitext(mod)[0])))
-            except ImportError:
-                candidate = None
-            if candidate:
-                for member in filter(filters.members, dir(candidate)):
-                    try:
-                        if issubclass(getattr(candidate, member), unittest.TestCase) \
-                           and getattr(candidate, member).__name__ != unittest.TestCase.__name__:
-                            test_classes.append(getattr(candidate, member))
-                    except TypeError:
-                        pass
+    for mod in __get_modules(test_dir, filters.files):
+        try:
+            candidate = importlib.import_module(mod)
+        except ImportError:
+            candidate = None
+        if candidate:
+            for member in filter(filters.members, dir(candidate)):
+                try:
+                    if issubclass(getattr(candidate, member), unittest.TestCase) \
+                       and getattr(candidate, member).__name__ != unittest.TestCase.__name__:
+                        test_classes.append(getattr(candidate, member))
+                except TypeError:
+                    pass
 
     return_code = EX_OK
 

--- a/scripts/runtest.py
+++ b/scripts/runtest.py
@@ -117,6 +117,24 @@ def __get_candidates(path, module_filter, member_filter):
                 yield (candidate, member)
 
 
+def __calc_ratio(dividend, divisor):
+    """
+    Calculate the ratio dividend:divisor
+    
+    This is a simple wrapper to perform an arithmetic division calculation.
+    In case of failure (e. g. divisor = zero), a result of 1 is returned.
+    
+    :param dividend: dividend number
+    :param divisor:  divisor number
+    :return:         float
+    """
+    try:
+        result = float(dividend) / float(divisor)
+    except ZeroDivisionError:
+        result = 1
+    return result
+
+
 def main():
     """
     xobox test script main function
@@ -173,10 +191,7 @@ def main():
         total_skipped += results[key][1]
         total_failed += results[key][0]
         total_passed = total_tests - total_failed - total_skipped
-        try:
-            ratio = float(results[key][2] - results[key][0] - results[key][1]) / float(results[key][2] - results[key][1])
-        except ZeroDivisionError:
-            ratio = 1
+        ratio = __calc_ratio(results[key][2] - results[key][0] - results[key][1], results[key][2] - results[key][1])
         print(
             "{test: <32}      {passed: >3d}      {failed: >3d}      {skipped: >4d}     {total: >3d}     {ratio: >3.2%}".format(
             test=key,
@@ -187,10 +202,7 @@ def main():
             ratio=ratio
         ))
     print("================================================================================")
-    try:
-        ratio = float(total_passed) / float(total_tests-total_skipped)
-    except ZeroDivisionError:
-        ratio = 1
+    ratio = __calc_ratio(total_passed, total_tests - total_skipped)
     print("{test: <32}      {passed: >3d}      {failed: >3d}      {skipped: >4d}     {total: >3d}     {ratio: >3.2%}\n".format(
         test="TOTAL",
         passed=total_passed,


### PR DESCRIPTION
### Summary

Reduce the complexity of runtest.py by properly modularizing the code

### Benefits

improved maintainability

### Drawbacks and Risks 

Architecture changes can possibly break the script

### Alternate Designs

Use full list references instead of generators => higher memory consumption, not necessary in the given context as iteration only happens once

### Applicable Issues

Fixes #36 
